### PR TITLE
Assertions refactoring

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
@@ -57,9 +57,6 @@ public class AttributeMatcher {
    * @return true if this matcher is matching provided value, false otherwise.
    */
   boolean matchesValue(String value) {
-    if (attributeValue == null) {
-      return true;
-    }
-    return Objects.equals(attributeValue, value);
+    return attributeValue == null || attributeValue.equals(value);
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.contrib.jmxscraper.assertions;
 
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 /** Implements functionality of matching data point attributes. */

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcher.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.contrib.jmxscraper.assertions;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /** Implements functionality of matching data point attributes. */
 public class AttributeMatcher {
   private final String attributeName;
-  @Nullable
-  private final String attributeValue;
+  @Nullable private final String attributeValue;
 
   /**
    * Create instance used to match data point attribute with any value.
@@ -29,7 +29,7 @@ public class AttributeMatcher {
    * @param attributeName attribute name
    * @param attributeValue attribute value
    */
-  AttributeMatcher(String attributeName, String attributeValue) {
+  AttributeMatcher(String attributeName, @Nullable String attributeValue) {
     this.attributeName = attributeName;
     this.attributeValue = attributeValue;
   }
@@ -41,24 +41,6 @@ public class AttributeMatcher {
    */
   public String getAttributeName() {
     return attributeName;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AttributeMatcher)) {
-      return false;
-    }
-    AttributeMatcher other = (AttributeMatcher) o;
-    return Objects.equals(attributeName, other.attributeName);
-  }
-
-  @Override
-  public int hashCode() {
-    // Do not use value matcher here to support value wildcards
-    return Objects.hash(attributeName);
   }
 
   @Override
@@ -76,7 +58,7 @@ public class AttributeMatcher {
    * @return true if this matcher is matching provided value, false otherwise.
    */
   boolean matchesValue(String value) {
-    if ((attributeValue == null) || (value == null)) {
+    if (attributeValue == null) {
       return true;
     }
     return Objects.equals(attributeValue, value);

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherGroup.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherGroup.java
@@ -9,8 +9,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-/** Holder class for a set of attribute matchers */
-public class AttributeMatcherSet {
+/** Group of attribute matchers */
+public class AttributeMatcherGroup {
 
   // stored as a Map for easy lookup by name
   private final Map<String, AttributeMatcher> matchers;
@@ -18,19 +18,19 @@ public class AttributeMatcherSet {
   /**
    * Constructor for a set of attribute matchers
    *
-   * @param matchers collection of matchers to build a set from
+   * @param matchers collection of matchers to build a group from
    * @throws IllegalStateException if there is any duplicate key
    */
-  AttributeMatcherSet(Collection<AttributeMatcher> matchers) {
+  AttributeMatcherGroup(Collection<AttributeMatcher> matchers) {
     this.matchers =
         matchers.stream().collect(Collectors.toMap(AttributeMatcher::getAttributeName, m -> m));
   }
 
   /**
-   * Checks if attributes match this attribute matcher set
+   * Checks if attributes match this attribute matcher group
    *
    * @param attributes attributes to check as map
-   * @return {@literal true} when the attributes match all attributes from this set
+   * @return {@literal true} when the attributes match all attributes from this group
    */
   public boolean matches(Map<String, String> attributes) {
     if (attributes.size() != matchers.size()) {

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
@@ -30,6 +30,33 @@ public class AttributeMatcherSet {
     return matchers;
   }
 
+  /**
+   * Checks if attributes match this attribute matcher set
+   *
+   * @param attributes attributes to check as map
+   * @return {@literal true} when the attributes match all attributes from this set
+   */
+  public boolean matches(Map<String, String> attributes) {
+    if(attributes.size() != matchers.size()) {
+      return false;
+    }
+
+    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+      AttributeMatcher matcher = matchers.get(entry.getKey());
+      if (matcher == null) {
+        // no matcher for this key: unexpected key
+        return false;
+      }
+
+      if (!matcher.matchesValue(entry.getValue())) {
+        // value does not match: unexpected value
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   @Override
   public String toString() {
     return matchers.values().toString();

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.assertions;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Holder class for a set of attribute matchers */
+public class AttributeMatcherSet {
+
+  // stored as a Map for easy lookup by name
+  private final Map<String, AttributeMatcher> matchers;
+
+  /**
+   * Constructor for a set of attribute matchers
+   *
+   * @param matchers collection of matchers to build a set from
+   * @throws IllegalStateException if there is any duplicate key
+   */
+  AttributeMatcherSet(Collection<AttributeMatcher> matchers) {
+    this.matchers =
+        matchers.stream().collect(Collectors.toMap(AttributeMatcher::getAttributeName, m -> m));
+  }
+
+  Map<String, AttributeMatcher> getMatchers() {
+    return matchers;
+  }
+
+  @Override
+  public String toString() {
+    return matchers.values().toString();
+  }
+}

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/AttributeMatcherSet.java
@@ -26,10 +26,6 @@ public class AttributeMatcherSet {
         matchers.stream().collect(Collectors.toMap(AttributeMatcher::getAttributeName, m -> m));
   }
 
-  Map<String, AttributeMatcher> getMatchers() {
-    return matchers;
-  }
-
   /**
    * Checks if attributes match this attribute matcher set
    *
@@ -37,7 +33,7 @@ public class AttributeMatcherSet {
    * @return {@literal true} when the attributes match all attributes from this set
    */
   public boolean matches(Map<String, String> attributes) {
-    if(attributes.size() != matchers.size()) {
+    if (attributes.size() != matchers.size()) {
       return false;
     }
 

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/DataPointAttributes.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/DataPointAttributes.java
@@ -38,16 +38,16 @@ public class DataPointAttributes {
   }
 
   /**
-   * Create a set of attribute matchers that should be used to verify set of data point attributes.
+   * Creates a group of attribute matchers that should be used to verify data point attributes.
    *
-   * @param attributes list of matchers to create set. It must contain matchers with unique names.
-   * @return set of unique attribute matchers
+   * @param attributes list of matchers to create group. It must contain matchers with unique names.
+   * @return group of attribute matchers
    * @throws IllegalArgumentException if provided list contains two or more matchers with the same
-   *     name.
-   * @see MetricAssert#hasDataPointsWithAttributes(AttributeMatcherSet...) for detailed description
-   *     off the algorithm used for matching
+   *     attribute name
+   * @see MetricAssert#hasDataPointsWithAttributes(AttributeMatcherGroup...) for detailed
+   *     description off the algorithm used for matching
    */
-  public static AttributeMatcherSet attributeSet(AttributeMatcher... attributes) {
-    return new AttributeMatcherSet(Arrays.asList(attributes));
+  public static AttributeMatcherGroup attributeGroup(AttributeMatcher... attributes) {
+    return new AttributeMatcherGroup(Arrays.asList(attributes));
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/DataPointAttributes.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/DataPointAttributes.java
@@ -6,8 +6,6 @@
 package io.opentelemetry.contrib.jmxscraper.assertions;
 
 import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Utility class implementing convenience static methods to construct data point attribute matchers
@@ -46,15 +44,10 @@ public class DataPointAttributes {
    * @return set of unique attribute matchers
    * @throws IllegalArgumentException if provided list contains two or more matchers with the same
    *     name.
-   * @see MetricAssert#hasDataPointsWithAttributes(Set[]) for detailed description of the algorithm
-   *     used for matching
+   * @see MetricAssert#hasDataPointsWithAttributes(AttributeMatcherSet...) for detailed description
+   *     off the algorithm used for matching
    */
-  public static Set<AttributeMatcher> attributeSet(AttributeMatcher... attributes) {
-    Set<AttributeMatcher> matcherSet = Arrays.stream(attributes).collect(Collectors.toSet());
-    if (matcherSet.size() < attributes.length) {
-      throw new IllegalArgumentException(
-          "Duplicated matchers found in " + Arrays.toString(attributes));
-    }
-    return matcherSet;
+  public static AttributeMatcherSet attributeSet(AttributeMatcher... attributes) {
+    return new AttributeMatcherSet(Arrays.asList(attributes));
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -264,7 +264,8 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
 
           // validate each datapoint attributes match exactly one of the provided attributes sets
           for (NumberDataPoint dataPoint : dataPoints) {
-            Map<String, String> dataPointAttributes = toMap(dataPoint.getAttributesList());
+            Map<String, String> dataPointAttributes = dataPoint.getAttributesList().stream()
+                .collect(Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue()));
             int matchCount = 0;
             for (int i = 0; i < attributeMatchers.length; i++) {
               if (attributeMatchers[i].matches(dataPointAttributes)) {
@@ -289,8 +290,4 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
         });
   }
 
-  private static Map<String, String> toMap(List<KeyValue> list) {
-    return list.stream()
-        .collect(Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue()));
-  }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -267,7 +267,7 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
             Map<String, String> dataPointAttributes = toMap(dataPoint.getAttributesList());
             int matchCount = 0;
             for (int i = 0; i < attributeMatchers.length; i++) {
-              if (matchAttributes(attributeMatchers[i], dataPointAttributes)) {
+              if (attributeMatchers[i].matches(dataPointAttributes)) {
                 matchedSets[i] = true;
                 matchCount++;
               }
@@ -287,41 +287,6 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
             objects.assertEqual(info, matchedSets[i], true);
           }
         });
-  }
-
-  private static boolean matchAttributes(
-      AttributeMatcherSet attributeMatcherSet, Map<String, String> dataPointAttributes) {
-
-    Map<String, AttributeMatcher> matchers = attributeMatcherSet.getMatchers();
-
-    Set<String> toMatch = new HashSet<>(dataPointAttributes.keySet());
-    Set<String> matched = new HashSet<>();
-    for (Map.Entry<String, String> entry : dataPointAttributes.entrySet()) {
-      AttributeMatcher matcher = matchers.get(entry.getKey());
-      if (matcher == null) {
-        // no matcher for this key: unexpected key
-        return false;
-      }
-
-      String value = entry.getValue();
-      if (!matcher.matchesValue(value)) {
-        // value does not match: unexpected value
-        return false;
-      }
-      toMatch.remove(entry.getKey());
-      matched.add(entry.getKey());
-    }
-
-    if (!toMatch.isEmpty()) {
-      // unexpected entries in attributes
-      return false;
-    }
-    if (!matched.containsAll(matchers.keySet())) {
-      // some matchers were not matched
-      return false;
-    }
-
-    return true;
   }
 
   private static Map<String, String> toMap(List<KeyValue> list) {

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.jmxscraper.assertions;
 
-import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -241,26 +241,26 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
    */
   @CanIgnoreReturnValue
   public final MetricAssert hasDataPointsWithOneAttribute(AttributeMatcher expectedAttribute) {
-    return hasDataPointsWithAttributes(attributeSet(expectedAttribute));
+    return hasDataPointsWithAttributes(attributeGroup(expectedAttribute));
   }
 
   /**
-   * Verifies that every data point attributes set is matched exactly by one of the matcher sets
-   * provided. Also, each matcher set must match at least one data point attributes set. Data point
-   * attributes set is matched by matcher set if each attribute is matched by one matcher and each
-   * matcher matches one attribute. In other words: number of attributes is the same as number of
-   * matchers and there is 1:1 matching between them.
+   * Verifies that every data point attributes is matched exactly by one of the matcher groups
+   * provided. Also, each matcher group must match at least one data point attributes set. Data
+   * point attributes are matched by matcher group if each attribute is matched by one matcher and
+   * each matcher matches one attribute. In other words: number of attributes is the same as number
+   * of matchers and there is 1:1 matching between them.
    *
-   * @param attributeMatchers array of attribute matcher sets
+   * @param matcherGroups array of attribute matcher groups
    * @return this
    */
   @CanIgnoreReturnValue
-  public final MetricAssert hasDataPointsWithAttributes(AttributeMatcherSet... attributeMatchers) {
+  public final MetricAssert hasDataPointsWithAttributes(AttributeMatcherGroup... matcherGroups) {
     return checkDataPoints(
         dataPoints -> {
           dataPointsCommonCheck(dataPoints);
 
-          boolean[] matchedSets = new boolean[attributeMatchers.length];
+          boolean[] matchedSets = new boolean[matcherGroups.length];
 
           // validate each datapoint attributes match exactly one of the provided attributes sets
           for (NumberDataPoint dataPoint : dataPoints) {
@@ -269,8 +269,8 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
                     .collect(
                         Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue()));
             int matchCount = 0;
-            for (int i = 0; i < attributeMatchers.length; i++) {
-              if (attributeMatchers[i].matches(dataPointAttributes)) {
+            for (int i = 0; i < matcherGroups.length; i++) {
+              if (matcherGroups[i].matches(dataPointAttributes)) {
                 matchedSets[i] = true;
                 matchCount++;
               }
@@ -278,7 +278,7 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
 
             info.description(
                 "data point attributes '%s' for metric '%s' must match exactly one of the attribute sets '%s'",
-                dataPointAttributes, actual.getName(), Arrays.asList(attributeMatchers));
+                dataPointAttributes, actual.getName(), Arrays.asList(matcherGroups));
             integers.assertEqual(info, matchCount, 1);
           }
 
@@ -286,7 +286,7 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
           for (int i = 0; i < matchedSets.length; i++) {
             info.description(
                 "no data point matched attribute set '%s' for metric '%s'",
-                attributeMatchers[i], actual.getName());
+                matcherGroups[i], actual.getName());
             objects.assertEqual(info, matchedSets[i], true);
           }
         });

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -264,8 +264,10 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
 
           // validate each datapoint attributes match exactly one of the provided attributes sets
           for (NumberDataPoint dataPoint : dataPoints) {
-            Map<String, String> dataPointAttributes = dataPoint.getAttributesList().stream()
-                .collect(Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue()));
+            Map<String, String> dataPointAttributes =
+                dataPoint.getAttributesList().stream()
+                    .collect(
+                        Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue()));
             int matchCount = 0;
             for (int i = 0; i < attributeMatchers.length; i++) {
               if (attributeMatchers[i].matches(dataPointAttributes)) {
@@ -289,5 +291,4 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
           }
         });
   }
-
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -255,7 +255,6 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
    * @return this
    */
   @CanIgnoreReturnValue
-  @SuppressWarnings("varargs") // required to avoid warning
   public final MetricAssert hasDataPointsWithAttributes(AttributeMatcherSet... attributeMatchers) {
     return checkDataPoints(
         dataPoints -> {
@@ -318,7 +317,7 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
       return false;
     }
     if (!matched.containsAll(matchers.keySet())) {
-      // some matchers were not match
+      // some matchers were not matched
       return false;
     }
 

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/ActiveMqIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/ActiveMqIntegrationTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.contrib.jmxscraper.target_systems;
 
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
-import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
 
 import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
 import java.nio.file.Path;
@@ -48,7 +48,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{consumer}")
                     .isUpDownCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -59,7 +59,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{producer}")
                     .isUpDownCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -78,7 +78,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("%")
                     .isGauge()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -107,7 +107,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{message}")
                     .isUpDownCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -119,7 +119,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{message}")
                     .isCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -130,7 +130,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{message}")
                     .isCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -141,7 +141,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("{message}")
                     .isCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))))
         .add(
@@ -152,7 +152,7 @@ public class ActiveMqIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("ms")
                     .isGauge()
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("destination", "ActiveMQ.Advisory.MasterBroker"),
                             attribute("broker", "localhost"))));
   }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
@@ -9,10 +9,9 @@ import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
 
 import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
-import io.opentelemetry.contrib.jmxscraper.assertions.AttributeMatcher;
+import io.opentelemetry.contrib.jmxscraper.assertions.AttributeMatcherSet;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Set;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -184,7 +183,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
                         errorCountAttributes("Write", "Unavailable")));
   }
 
-  private static Set<AttributeMatcher> errorCountAttributes(String operation, String status) {
+  private static AttributeMatcherSet errorCountAttributes(String operation, String status) {
     return attributeSet(attribute("operation", operation), attribute("status", status));
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.contrib.jmxscraper.target_systems;
 
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
-import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
 
 import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
-import io.opentelemetry.contrib.jmxscraper.assertions.AttributeMatcherSet;
+import io.opentelemetry.contrib.jmxscraper.assertions.AttributeMatcherGroup;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
@@ -161,9 +161,9 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
                     .hasUnit("1")
                     .isCounter()
                     .hasDataPointsWithAttributes(
-                        attributeSet(attribute("operation", "RangeSlice")),
-                        attributeSet(attribute("operation", "Read")),
-                        attributeSet(attribute("operation", "Write"))))
+                        attributeGroup(attribute("operation", "RangeSlice")),
+                        attributeGroup(attribute("operation", "Read")),
+                        attributeGroup(attribute("operation", "Write"))))
         .add(
             "cassandra.client.request.error.count",
             metric ->
@@ -183,7 +183,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
                         errorCountAttributes("Write", "Unavailable")));
   }
 
-  private static AttributeMatcherSet errorCountAttributes(String operation, String status) {
-    return attributeSet(attribute("operation", operation), attribute("status", status));
+  private static AttributeMatcherGroup errorCountAttributes(String operation, String status) {
+    return attributeGroup(attribute("operation", operation), attribute("status", status));
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.contrib.jmxscraper.target_systems;
 
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
-import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeWithAnyValue;
 
 import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
@@ -44,8 +44,8 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The number of region servers.")
                     .hasUnit("{server}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(attribute("state", "dead")),
-                        attributeSet(attribute("state", "live"))))
+                        attributeGroup(attribute("state", "dead")),
+                        attributeGroup(attribute("state", "live"))))
         .add(
             "hbase.master.regions_in_transition.count",
             metric ->
@@ -128,9 +128,9 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The number of requests received.")
                     .hasUnit("{request}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "write"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "read"), attributeWithAnyValue("region_server"))))
         .add(
             "hbase.region_server.queue.length",
@@ -140,9 +140,9 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The number of RPC handlers actively servicing requests.")
                     .hasUnit("{handler}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "flush"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "compaction"),
                             attributeWithAnyValue("region_server"))))
         .add(
@@ -162,9 +162,9 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("Number of block cache hits/misses.")
                     .hasUnit("{operation}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "miss"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "hit"), attributeWithAnyValue("region_server"))))
         .add(
             "hbase.region_server.files.local",
@@ -436,17 +436,17 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("Number of operations that took over 1000ms to complete.")
                     .hasUnit("{operation}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("operation", "delete"),
                             attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("operation", "append"),
                             attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("operation", "get"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("operation", "put"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("operation", "increment"),
                             attributeWithAnyValue("region_server"))))
         .add(
@@ -473,12 +473,12 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The number of currently enqueued requests.")
                     .hasUnit("{request}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "replication"),
                             attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "user"), attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "priority"),
                             attributeWithAnyValue("region_server"))))
         .add(
@@ -490,10 +490,10 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
                         "Number of client connection authentication failures/successes.")
                     .hasUnit("{authentication request}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "successes"),
                             attributeWithAnyValue("region_server")),
-                        attributeSet(
+                        attributeGroup(
                             attribute("state", "failures"),
                             attributeWithAnyValue("region_server"))))
         .add(

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JettyIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JettyIntegrationTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.contrib.jmxscraper.target_systems;
 
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
-import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeSet;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
 import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeWithAnyValue;
 
 import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
@@ -88,7 +88,7 @@ public class JettyIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The number of select calls.")
                     .hasUnit("{operation}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(
+                        attributeGroup(
                             attributeWithAnyValue("context"), attributeWithAnyValue("id"))))
         .add(
             "jetty.thread.count",
@@ -98,8 +98,8 @@ public class JettyIntegrationTest extends TargetSystemIntegrationTest {
                     .hasDescription("The current number of threads.")
                     .hasUnit("{thread}")
                     .hasDataPointsWithAttributes(
-                        attributeSet(attribute("state", "busy")),
-                        attributeSet(attribute("state", "idle"))))
+                        attributeGroup(attribute("state", "busy")),
+                        attributeGroup(attribute("state", "idle"))))
         .add(
             "jetty.thread.queue.count",
             metric ->


### PR DESCRIPTION
- creating a dedicated `AttributeMatcherSet` class that is backed by a map
- using a dedicated collection class allows to avoid warnings with varargs parameters with have with `Collection<?>...` for method arguments.
- attribute keys uniqueness is enforced by the map collector.
- rename to "attribute group" to avoid ambiguity with `Set` in java collections